### PR TITLE
Use <Unmarshaller<T> as Unmarshall>::Data as msg

### DIFF
--- a/microservices/src/peer/mod.rs
+++ b/microservices/src/peer/mod.rs
@@ -12,55 +12,66 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 mod peer_connection;
+use crate::node::TryService;
+use internet2::presentation::{Error, TypedEnum, Unmarshall, Unmarshaller};
 pub use peer_connection::{
     PeerConnection, PeerReceiver, PeerSender, RecvMessage, SendMessage,
 };
-use internet2::presentation::{Error, CreateUnmarshaller, Unmarshaller, Unmarshall, TypedEnum} ;
-use crate::node::TryService;
-use std::fmt::{Display, Debug};
+use std::fmt::{Debug, Display};
 
 /// Trait for types handling specific LNPWP messages.
-pub trait Handler {
+pub trait Handler<T: TypedEnum> {
     type Error: crate::error::Error + From<Error>;
 
     /// Function that processes specific peer message
-    fn handle(&mut self, message: impl CreateUnmarshaller) -> Result<(), Self::Error>;
+    fn handle(
+        &mut self,
+        message: <Unmarshaller<T> as Unmarshall>::Data,
+    ) -> Result<(), Self::Error>;
 
     fn handle_err(&mut self, error: Self::Error) -> Result<(), Self::Error>;
 }
 
 pub struct Listener<H, T>
 where
-    H: Handler,
     T: TypedEnum,
+    H: Handler<T>,
     Unmarshaller<T>: Unmarshall,
-    <Unmarshaller<T> as Unmarshall>::Data: CreateUnmarshaller + Display + Debug,
+    <Unmarshaller<T> as Unmarshall>::Data: Display + Debug,
     <Unmarshaller<T> as Unmarshall>::Error: Into<Error>,
 {
     receiver: PeerReceiver,
     handler: H,
-    unmarshall: Unmarshaller<T>,
+    unmarshaller: Unmarshaller<T>,
 }
 
 impl<H, T> Listener<H, T>
 where
-    H: Handler,
     T: TypedEnum,
+    H: Handler<T>,
     Unmarshaller<T>: Unmarshall,
-    <Unmarshaller<T> as Unmarshall>::Data: CreateUnmarshaller + Display + Debug,
+    <Unmarshaller<T> as Unmarshall>::Data: Display + Debug,
     <Unmarshaller<T> as Unmarshall>::Error: Into<Error>,
 {
-    pub fn with(receiver: PeerReceiver, handler: H, unmarshall: Unmarshaller<T>) -> Self {
-        Self { receiver, handler, unmarshall }
+    pub fn with(
+        receiver: PeerReceiver,
+        handler: H,
+        unmarshaller: Unmarshaller<T>,
+    ) -> Self {
+        Self {
+            receiver,
+            handler,
+            unmarshaller,
+        }
     }
 }
 
 impl<H, T> TryService for Listener<H, T>
 where
-    H: Handler,
     T: TypedEnum,
+    H: Handler<T>,
     Unmarshaller<T>: Unmarshall,
-    <Unmarshaller<T> as Unmarshall>::Data: CreateUnmarshaller + Display + Debug,
+    <Unmarshaller<T> as Unmarshall>::Data: Display + Debug,
     <Unmarshaller<T> as Unmarshall>::Error: Into<Error>,
 {
     type ErrorType = H::Error;
@@ -79,18 +90,17 @@ where
     }
 }
 
-
 impl<H, T> Listener<H, T>
 where
-    H: Handler,
     T: TypedEnum,
+    H: Handler<T>,
     Unmarshaller<T>: Unmarshall,
-    <Unmarshaller<T> as Unmarshall>::Data: CreateUnmarshaller + Display + Debug,
+    <Unmarshaller<T> as Unmarshall>::Data: Display + Debug,
     <Unmarshaller<T> as Unmarshall>::Error: Into<Error>,
 {
     fn run(&mut self) -> Result<(), H::Error> {
         trace!("Awaiting for peer messages...");
-        let msg = self.receiver.recv_message(&self.unmarshall)?;
+        let msg = self.receiver.recv_message(&self.unmarshaller)?;
         debug!("Processing message {}", msg);
         trace!("Message details: {:?}", msg);
         self.handler.handle(msg)


### PR DESCRIPTION
e.g., to instantiate the peer::Listener

``` rust
    let unmarshaller: Unmarshaller<Msg> = Msg::create_unmarshaller();
    let listener =
        peer::Listener::<ListenerRuntime, Msg>::with(receiver, bridge_handler, unmarshaller);
```