### PR TITLE
Removing dependency on rust-bitcoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,6 @@ dependencies = [
  "bech32",
  "bitcoin_hashes",
  "secp256k1",
- "serde",
 ]
 
 [[package]]
@@ -545,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "inet2_addr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "amplify",
  "ed25519-dalek",
@@ -561,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "inet2_derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -585,15 +584,16 @@ dependencies = [
 
 [[package]]
 name = "internet2"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "amplify",
- "bitcoin",
+ "bitcoin_hashes",
  "chacha20poly1305",
  "inet2_addr",
  "inet2_derive",
  "lazy_static",
  "lightning_encoding",
+ "secp256k1",
  "serde",
  "serde_with",
  "strict_encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "internet2"
-version = "0.5.0"
+version = "0.6.0"
 license = "Apache-2.0"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 description = "Rust implementation for the stack of Internet2 protocols"
@@ -25,11 +25,12 @@ crate-type = ["rlib", "staticlib"]
 amplify = "3.9.1"
 strict_encoding = { version = "1.7", default-features = false, features = ["derive"] }
 lightning_encoding = "0.5.0"
-inet2_addr = { version = "0.5", features = ["strict_encoding", "stringly_conversions"], path = "./addr" }
-inet2_derive = { version = "0.5.0", default-features = false, optional = true, path = "./derive" }
+inet2_addr = { version = "0.6.0", features = ["strict_encoding", "stringly_conversions"], path = "./addr" }
+inet2_derive = { version = "0.6.0", default-features = false, optional = true, path = "./derive" }
 # Dependencies on core rust-bitcoin & cryptography
 # ------------------------------------------------
-bitcoin = { version = "0.27.1", default-features = false, features = ["rand"] }
+secp256k1 = "0.20.3"
+bitcoin_hashes = "0.10.0"
 chacha20poly1305 = "0.7"
 # Core rust projects
 # ------------------
@@ -71,9 +72,9 @@ all = ["derive",
 # ----------------------------
 #   These also include re-assembly of necessary features from dependencies
 serde = ["serde_crate", "serde_with", "amplify/serde",
-         "bitcoin/use-serde", "inet2_addr/serde"]
+         "inet2_addr/serde", "secp256k1/serde", "bitcoin_hashes/serde-std"]
 derive = ["inet2_derive"]
-keygen = ["bitcoin/rand"]
+keygen = ["secp256k1/rand-std"]
 # Networking
 # ----------
 websockets = []

--- a/addr/Cargo.toml
+++ b/addr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inet2_addr"
-version = "0.5.0"
+version = "0.6.0"
 license = "Apache-2.0"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 description = "Internet2 addresses with support for Tor v2, v3"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inet2_derive"
-version = "0.5.0"
+version = "0.6.0"
 license = "Apache-2.0"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 description = "Derivation macros for Internet2-based crates"
@@ -22,7 +22,7 @@ amplify = "3.9.1"
 [dev-dependencies]
 amplify = "3.9.1"
 internet2 = { path = ".." }
-lnpbp = "0.5.0-beta.3"
+lnpbp = "0.5.0"
 strict_encoding = "1.7.1"
 lightning_encoding = "0.5.0"
 bitcoin = "0.27"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ pub enum AddrError {
     MalformedInetAddr(inet2_addr::AddrParseError),
 
     /// Invalid public key data representing node id
-    #[from(bitcoin::secp256k1::Error)]
+    #[from(secp256k1::Error)]
     InvalidPubkey,
 
     /// No host information found in URL, while it is required for the given

--- a/src/presentation/error.rs
+++ b/src/presentation/error.rs
@@ -45,11 +45,6 @@ pub enum Error {
     #[from]
     StrictEncoding(strict_encoding::Error),
 
-    /// Error in consensus-encoded data from LNP message
-    #[display(inner)]
-    #[from(bitcoin::consensus::encode::Error)]
-    ConsensusEncoding,
-
     /// unknown data type in LNP message
     #[from(UnknownTypeError)]
     UnknownDataType,
@@ -91,7 +86,6 @@ impl From<Error> for u8 {
             Error::UnknownProtocolVersion => 0x12,
             Error::LightningEncoding(_) => 0x20,
             Error::StrictEncoding(_) => 0x21,
-            Error::ConsensusEncoding => 0x22,
             Error::UnknownDataType => 0x23,
             Error::InvalidValue => 0x24,
             Error::MessageEvenType => 0x30,

--- a/src/presentation/message.rs
+++ b/src/presentation/message.rs
@@ -17,10 +17,6 @@ use std::convert::TryInto;
 use std::io;
 use std::sync::Arc;
 
-use bitcoin::consensus::encode::{
-    self as consensus_encoding, Decodable as ConsensusDecode,
-    Encodable as ConsensusEncode,
-};
 use lightning_encoding::{self, LightningDecode, LightningEncode};
 use strict_encoding::{self, StrictEncode};
 
@@ -65,25 +61,6 @@ impl LightningDecode for TypeId {
         let mut id = [0u8; 2];
         d.read_exact(&mut id)?;
         Ok(Self(u16::from_be_bytes(id)))
-    }
-}
-
-impl ConsensusEncode for TypeId {
-    fn consensus_encode<W: io::Write>(
-        &self,
-        mut e: W,
-    ) -> Result<usize, io::Error> {
-        Ok(e.write(&self.0.to_le_bytes())?)
-    }
-}
-
-impl ConsensusDecode for TypeId {
-    fn consensus_decode<D: io::Read>(
-        mut d: D,
-    ) -> Result<Self, consensus_encoding::Error> {
-        let mut id = [0u8; 2];
-        d.read_exact(&mut id)?;
-        Ok(Self(u16::from_le_bytes(id)))
     }
 }
 
@@ -153,15 +130,6 @@ impl LightningEncode for Payload {
         mut e: E,
     ) -> Result<usize, lightning_encoding::Error> {
         Ok(self.type_id.lightning_encode(&mut e)? + e.write(&self.payload)?)
-    }
-}
-
-impl ConsensusEncode for Payload {
-    fn consensus_encode<W: io::Write>(
-        &self,
-        mut e: W,
-    ) -> Result<usize, io::Error> {
-        Ok(self.type_id.consensus_encode(&mut e)? + e.write(&self.payload)?)
     }
 }
 

--- a/src/presentation/mod.rs
+++ b/src/presentation/mod.rs
@@ -49,7 +49,4 @@ pub enum EncodingType {
 
     #[display("strict-encoding")]
     Strict,
-
-    #[display("consensus-encoding")]
-    Bitcoin,
 }

--- a/src/presentation/unmarshall.rs
+++ b/src/presentation/unmarshall.rs
@@ -19,7 +19,6 @@ use std::io::{self, Read};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use bitcoin::consensus::encode::Decodable as ConsensusDecode;
 use lightning_encoding::LightningDecode;
 use strict_encoding::{self, StrictDecode};
 
@@ -65,7 +64,6 @@ where
         let type_id = match self.encoding {
             EncodingType::Lightning => TypeId::lightning_decode(&mut reader)?,
             EncodingType::Strict => TypeId::strict_decode(&mut reader)?,
-            EncodingType::Bitcoin => TypeId::consensus_decode(&mut reader)?,
         };
         match self.known_types.get(&type_id) {
             None if type_id.is_even() => Err(Error::MessageEvenType),

--- a/src/session/local_node.rs
+++ b/src/session/local_node.rs
@@ -14,8 +14,8 @@
 use std::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "keygen")]
-use bitcoin::secp256k1::rand::thread_rng;
-use bitcoin::secp256k1::{self, Secp256k1};
+use secp256k1::rand::thread_rng;
+use secp256k1::{self, Secp256k1};
 
 lazy_static! {
     static ref SECP256K1: Secp256k1<secp256k1::All> = Secp256k1::new();

--- a/src/session/node_addr.rs
+++ b/src/session/node_addr.rs
@@ -22,7 +22,6 @@ use std::str::FromStr;
 #[cfg(feature = "url")]
 use url::Url;
 
-use bitcoin::secp256k1;
 use inet2_addr::{InetAddr, InetSocketAddr};
 
 use crate::transport::{LocalSocketAddr, RemoteSocketAddr};

--- a/src/session/noise/conduit.rs
+++ b/src/session/noise/conduit.rs
@@ -361,7 +361,7 @@ impl Bipolar for NoiseTranscoder {
 mod tests {
     use super::*;
     use crate::LNP_MSG_MAX_LEN;
-    use bitcoin::hashes::hex::FromHex;
+    use bitcoin_hashes::hex::FromHex;
 
     fn setup_peers() -> (NoiseTranscoder, NoiseTranscoder) {
         let chaining_key_vec = Vec::<u8>::from_hex(

--- a/src/session/noise/handshake.rs
+++ b/src/session/noise/handshake.rs
@@ -11,11 +11,9 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use bitcoin::secp256k1;
-
-use bitcoin::hashes::sha256::Hash as Sha256;
-use bitcoin::hashes::{Hash, HashEngine};
-use bitcoin::secp256k1::{PublicKey, SecretKey};
+use bitcoin_hashes::sha256::Hash as Sha256;
+use bitcoin_hashes::{Hash, HashEngine};
+use secp256k1::{PublicKey, SecretKey};
 
 use super::act::{
     Act, ActBuilder, ACT_ONE_LENGTH, ACT_THREE_LENGTH, ACT_TWO_LENGTH,
@@ -672,10 +670,8 @@ mod test {
     use super::HandshakeState::*;
     use super::*;
 
-    use bitcoin::hashes::hex::{FromHex, ToHex};
-
-    use bitcoin::secp256k1;
-    use bitcoin::secp256k1::{PublicKey, SecretKey};
+    use bitcoin_hashes::hex::{FromHex, ToHex};
+    use secp256k1::{PublicKey, SecretKey};
 
     struct TestCtx {
         initiator: HandshakeState,

--- a/src/session/noise/hkdf.rs
+++ b/src/session/noise/hkdf.rs
@@ -11,8 +11,8 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use bitcoin::hashes::sha256::Hash as Sha256;
-use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine};
+use bitcoin_hashes::sha256::Hash as Sha256;
+use bitcoin_hashes::{Hash, HashEngine, Hmac, HmacEngine};
 
 // Allows 1 or more inputs and "concatenates" them together using the input()
 // function of HmacEngine::<Sha256>
@@ -66,7 +66,7 @@ pub(super) fn derive(salt: &[u8], ikm: &[u8]) -> ([u8; 32], [u8; 32]) {
 #[cfg(test)]
 mod test {
     use super::derive;
-    use bitcoin::hashes::hex::FromHex;
+    use amplify::hex::FromHex;
 
     // Test with SHA-256 and zero-length salt/info
     // Our implementation uses a zero-length info field and returns the first 64


### PR DESCRIPTION
There were three situations where rust-bitcoin crate was used in this project:
1. Use of bitcoin hashes library
2. Use of Secp256k1 library
3. Use of bitcoin consensus encoding

In order to shorten compilation time and removes conflicts with downstream crates using different versions of rust-bitcoin it is decided to get rid from this dependency.

The first two are replaced with direct dependencies on the underlying crates. As for the use of bitcoin consensus encoding, it is really specific for bitcoin network protocol and should be discouraged to use in internet2 projects where strict encoding should be used instead (or, at least, lightning encoding, where it is required by lightning network interoperability). Bitcoin network does not uses encryption so communications between future bitcoin nodes should be made via Bifrost using strict and not bitcoin encoding.