### PR TITLE
TLV refactoring according to lightning standards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "inet2_derive"
-version = "0.5.0"
+version = "0.5.4"
 dependencies = [
  "amplify",
  "internet2",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "internet2"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "amplify",
  "bitcoin_hashes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "amplify"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +73,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
 name = "autocfg"
@@ -261,6 +276,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "compiletest_rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29843cb8d351febf86557681d049d1e1652b81a086a190fa1173c07fd17fbf83"
+dependencies = [
+ "diff",
+ "filetime",
+ "getopts",
+ "lazy_static",
+ "libc",
+ "log",
+ "miow",
+ "regex",
+ "rustfix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tester",
+ "winapi",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,12 +432,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -434,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_derive_helpers"
-version = "1.7.5"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df85c511a2f01954d1fad7d7d20eeae1af35157fbaec35261c91fab53d76bb58"
+checksum = "dc4ba8a88067b85c8714922db6e5f2af47b894d63b771dbb0c4d31d6607e9057"
 dependencies = [
  "amplify",
  "proc-macro2",
@@ -449,6 +513,18 @@ name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
 
 [[package]]
 name = "fnv"
@@ -483,6 +559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,10 +579,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hex"
@@ -588,6 +693,7 @@ dependencies = [
  "amplify",
  "bitcoin_hashes",
  "chacha20poly1305",
+ "compiletest_rs",
  "inet2_addr",
  "inet2_derive",
  "lazy_static",
@@ -596,6 +702,7 @@ dependencies = [
  "serde",
  "serde_with",
  "strict_encoding",
+ "strict_encoding_derive",
  "strict_encoding_test",
  "torut",
  "url",
@@ -629,9 +736,9 @@ checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
 name = "lightning_encoding"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bea434dac862c2a050b55d9491b8ed2cad8b834361098369329e0a4ed8e544"
+checksum = "958827d3484c6986b2abbead07ca44b9d209c696355aa3ea3759afb808f50722"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -644,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "lightning_encoding_derive"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc5449b552f69a6cf6f1c580c0444018f9b592edf0119cf66cc3fc3caf62744"
+checksum = "da2093982a69f3230186cc918f377804bc59a47560a1763cba0ecd16e9d0d6a0"
 dependencies = [
  "amplify_syn",
  "encoding_derive_helpers",
@@ -741,6 +848,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +873,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -866,7 +992,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -914,7 +1040,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -998,12 +1124,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.3",
+ "redox_syscall",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e"
+dependencies = [
+ "anyhow",
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1165,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "strict_encoding"
-version = "1.7.5"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaf948106af4d241175fc5b4e64d63bea622430894c21fc72e4254be2e277ec"
+checksum = "b902832c1b2e32263327690284517021aa80ac999d4eef88ca549e9ccf47870c"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -1179,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "strict_encoding_derive"
-version = "1.7.5"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af01d535c6668a1386dcf8e8b090a1456574cfd564dad059c2e497e4930764"
+checksum = "3bc7b868cb00c8861784b7f463c984c4b2ad20d1f23cec5997ad9cb41e559239"
 dependencies = [
  "amplify_syn",
  "encoding_derive_helpers",
@@ -1191,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "strict_encoding_test"
-version = "1.7.4"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbc8dacf48120f716eb205cff27ce662af4e4f53f72ca139b50eade05640de0"
+checksum = "d7bd0bdf8da419af27970c9e16e99e23ec67b5c8b6896db950c93a6ba1827b2a"
 dependencies = [
  "amplify",
  "strict_encoding",
@@ -1242,6 +1416,30 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "tester"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0639d10d8f4615f223a57275cf40f9bdb7cfbb806bcb7f7cc56e3beb55a576eb"
+dependencies = [
+ "cfg-if",
+ "getopts",
+ "libc",
+ "num_cpus",
+ "term",
 ]
 
 [[package]]
@@ -1337,6 +1535,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ required-features = ["keygen"]
 # Dependencies on other LNP/BP repositories
 # -----------------------------------------
 amplify = "3.9.1"
-strict_encoding = { version = "1.7", default-features = false, features = ["derive"] }
-lightning_encoding = "0.5.0"
+strict_encoding = { version = ">=1.7.6", default-features = false, features = ["derive"] }
+lightning_encoding = ">=0.5.3"
 inet2_addr = { version = "0.5.0", features = ["strict_encoding", "stringly_conversions"], path = "./addr" }
 inet2_derive = { version = "0.5.0", default-features = false, optional = true, path = "./derive" }
 # Dependencies on core rust-bitcoin & cryptography
@@ -55,6 +55,8 @@ url = { version = "2", optional = true }
 [dev-dependencies]
 torut = "0.2.0"
 strict_encoding_test = "1.7.4"
+strict_encoding_derive = "1.7.6-beta.1"
+compiletest_rs = "0.7.0"
 
 [target.'cfg(target_os="android")'.dependencies]
 zmq = { version = "0.9", features = ["vendored"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "internet2"
-version = "0.5.3"
+version = "0.5.4"
 license = "Apache-2.0"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 description = "Rust implementation for the stack of Internet2 protocols"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -22,6 +22,6 @@ amplify = "3.9.1"
 [dev-dependencies]
 amplify = "3.9.1"
 internet2 = { path = ".." }
-strict_encoding = { version = "1.7.2", default-features = false, features = ["derive"] }
-lightning_encoding = "=0.5.0"
+strict_encoding = { version = ">=1.7.6", default-features = false, features = ["derive"] }
+lightning_encoding = ">=0.5.3"
 secp256k1 = "0.20.3"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inet2_derive"
-version = "0.5.0"
+version = "0.5.4"
 license = "Apache-2.0"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 description = "Derivation macros for Internet2-based crates"

--- a/derive/tests/api_lightning.rs
+++ b/derive/tests/api_lightning.rs
@@ -28,7 +28,7 @@ fn roundtrip() {
 
     let message = Request::Hello("world".to_owned());
     let payload = message.serialize();
-    assert_eq!(payload, b"\x00\x01\x05world".to_vec());
+    assert_eq!(payload, b"\x00\x01\x00\x05world".to_vec());
     let roundtrip = &*unmarshaller.unmarshall(&payload).unwrap();
     assert_eq!(&message, roundtrip);
 
@@ -54,7 +54,7 @@ fn roundtrip() {
     .collect();
     let message = Request::AddKeys(keys.clone());
     let payload = message.serialize();
-    let mut expect = b"\x01\x03\x02".to_vec();
+    let mut expect = b"\x01\x03\x00\x02".to_vec();
     expect.extend(keys.iter().map(secp256k1::PublicKey::serialize).flatten());
     assert_eq!(payload, expect);
     let roundtrip = &*unmarshaller.unmarshall(&payload).unwrap();

--- a/examples/tlv.rs
+++ b/examples/tlv.rs
@@ -1,0 +1,114 @@
+#![allow(dead_code)]
+
+#[macro_use]
+extern crate strict_encoding_derive;
+
+use std::collections::BTreeSet;
+
+use internet2::tlv;
+
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(StrictEncode, StrictDecode)]
+#[strict_encoding(by_value, repr = u16)]
+enum Feature {
+    #[strict_encoding(value = 0b0000_0000_0000_0001)]
+    PermanentConnection,
+
+    #[strict_encoding(value = 0b0000_0001_0000_0000)]
+    ProtocolV2,
+}
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default)]
+#[derive(NetworkEncode, NetworkDecode)]
+struct Stamp {
+    quality: u8,
+}
+
+impl Stamp {
+    pub fn iter(&self) -> Stamp { *self }
+}
+
+// We need TLV type to implement iterator, such we know whether it has value or
+// not
+impl Iterator for Stamp {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if *self == Self::default() {
+            None
+        } else {
+            Some(self.quality)
+        }
+    }
+}
+
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(NetworkEncode, NetworkDecode)]
+#[network_encoding(use_tlv)]
+struct Document {
+    pub name: String,
+
+    pub description: String,
+
+    #[network_encoding(tlv = 0x0101)]
+    pub signature: Vec<u8>,
+
+    #[network_encoding(tlv = 0x0201)]
+    pub stamp: Stamp,
+
+    #[network_encoding(unknown_tlvs)]
+    pub extra_fields: tlv::Stream,
+
+    #[network_encoding(skip)]
+    pub internal_use: Vec<u8>,
+}
+
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(NetworkEncode, NetworkDecode)]
+enum ProtocolMessages {
+    Init {
+        source: String,
+        destination: String,
+        features: BTreeSet<Feature>,
+    },
+
+    Ping,
+
+    Send(Document),
+}
+
+fn main() {
+    /*
+    impl strict_encoding::StrictDecode for TlvDefault {
+        #[inline]
+        fn strict_decode<D: ::std::io::Read>(
+            mut d: D,
+        ) -> ::core::result::Result<Self, strict_encoding::Error> {
+            use strict_encoding::StrictDecode;
+            let mut s = TlvDefault {
+                fixed: strict_encoding::StrictDecode::strict_decode(&mut d)?,
+                tlv: Default::default(),
+            };
+            let tlvs = BTreeMap::<usize, Box<[u8]>>::strict_decode(&mut d)?;
+            for (type_no, bytes) in tlvs {
+                match type_no {
+                    48879usize => {
+                        s.tlv =
+                            strict_encoding::StrictDecode::strict_deserialize(
+                                bytes,
+                            )?
+                    }
+                    _ if type_no % 2 == 0 => {
+                        return Err(strict_encoding::TlvError::UnknownEvenType(
+                            type_no,
+                        )
+                        .into())
+                    }
+                    _ => {}
+                }
+            }
+            Ok(s)
+        }
+    }
+     */
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,6 @@ extern crate amplify;
 #[macro_use]
 extern crate strict_encoding;
 #[macro_use]
-extern crate lightning_encoding;
-#[macro_use]
 extern crate lazy_static;
 
 extern crate chacha20poly1305;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,62 @@
+// LNP/BP client-side-validation foundation libraries implementing LNPBP
+// specifications & standards (LNPBP-4, 7, 8, 9, 42, 81)
+//
+// Written in 2019-2021 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the Apache 2.0 License along with this
+// software. If not, see <https://opensource.org/licenses/Apache-2.0>.
+
+extern crate compiletest_rs as compiletest;
+
+use std::fmt::{Debug, Display, Formatter};
+use std::path::PathBuf;
+
+use strict_encoding::{StrictDecode, StrictEncode};
+use strict_encoding_test::DataEncodingTestFailure;
+
+#[allow(dead_code)]
+pub fn compile_test(mode: &'static str) {
+    let mut config = compiletest::Config::default();
+
+    config.mode = mode.parse().expect("Invalid mode");
+    config.src_base = PathBuf::from(format!("tests/{}", mode));
+    config.link_deps(); // Populate config.target_rustcflags with dependencies on the path
+    config.clean_rmeta(); // If your tests import the parent crate, this helps with E0464
+
+    compiletest::run_tests(&config);
+}
+
+#[derive(Display)]
+#[display(inner)]
+pub struct Error(pub Box<dyn std::error::Error>);
+
+impl Debug for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.as_ref())
+    }
+}
+
+impl<T> From<strict_encoding_test::DataEncodingTestFailure<T>> for Error
+where
+    T: StrictEncode + StrictDecode + PartialEq + Debug + Clone + 'static,
+{
+    fn from(err: DataEncodingTestFailure<T>) -> Self { Self(Box::new(err)) }
+}
+
+impl From<strict_encoding::Error> for Error {
+    fn from(err: strict_encoding::Error) -> Self { Self(Box::new(err)) }
+}
+
+pub type Result = std::result::Result<(), Error>;

--- a/tests/tlv-failures/no_enums/mod.rs
+++ b/tests/tlv-failures/no_enums/mod.rs
@@ -1,0 +1,23 @@
+// LNP/BP client-side-validation foundation libraries implementing LNPBP
+// specifications & standards (LNPBP-4, 7, 8, 9, 42, 81)
+//
+// Written in 2019-2021 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the Apache 2.0 License along with this
+// software. If not, see <https://opensource.org/licenses/Apache-2.0>.
+
+#[macro_use]
+extern crate strict_encoding_derive;
+
+#[derive(NetworkEncode, NetworkDecode)]
+#[network_encoding(use_tlv)]
+enum Tlv {
+    CaseOne,
+    CaseTwo,
+}

--- a/tests/tlv-failures/no_strict/mod.rs
+++ b/tests/tlv-failures/no_strict/mod.rs
@@ -1,0 +1,23 @@
+// LNP/BP client-side-validation foundation libraries implementing LNPBP
+// specifications & standards (LNPBP-4, 7, 8, 9, 42, 81)
+//
+// Written in 2019-2021 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the Apache 2.0 License along with this
+// software. If not, see <https://opensource.org/licenses/Apache-2.0>.
+
+#[macro_use]
+extern crate strict_encoding_derive;
+
+#[derive(StrictEncode, StrictDecode)]
+#[strict_encoding(use_tlv)]
+struct Tlv {
+    #[strict_encoding(tlv = 0xCAFE)]
+    tlv: Option<u8>,
+}

--- a/tests/tlv-failures/no_unions/mod.rs
+++ b/tests/tlv-failures/no_unions/mod.rs
@@ -1,0 +1,23 @@
+// LNP/BP client-side-validation foundation libraries implementing LNPBP
+// specifications & standards (LNPBP-4, 7, 8, 9, 42, 81)
+//
+// Written in 2019-2021 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the Apache 2.0 License along with this
+// software. If not, see <https://opensource.org/licenses/Apache-2.0>.
+
+#[macro_use]
+extern crate strict_encoding_derive;
+
+#[derive(NetworkEncode, NetworkDecode)]
+#[network_encoding(use_tlv)]
+union Unit {
+    variant1: u16,
+    variant2: i16,
+}

--- a/tests/tlv-failures/tlv_non_u16_type/mod.rs
+++ b/tests/tlv-failures/tlv_non_u16_type/mod.rs
@@ -1,0 +1,23 @@
+// LNP/BP client-side-validation foundation libraries implementing LNPBP
+// specifications & standards (LNPBP-4, 7, 8, 9, 42, 81)
+//
+// Written in 2019-2021 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the Apache 2.0 License along with this
+// software. If not, see <https://opensource.org/licenses/Apache-2.0>.
+
+#[macro_use]
+extern crate strict_encoding_derive;
+
+#[derive(NetworkEncode, NetworkDecode)]
+#[network_encoding(use_tlv)]
+struct Tlv {
+    #[network_encoding(tlv = 0xCAFEBAD)]
+    tlv: Option<u8>,
+}

--- a/tests/tlv-failures/tlv_undeclared/mod.rs
+++ b/tests/tlv-failures/tlv_undeclared/mod.rs
@@ -1,0 +1,22 @@
+// LNP/BP client-side-validation foundation libraries implementing LNPBP
+// specifications & standards (LNPBP-4, 7, 8, 9, 42, 81)
+//
+// Written in 2019-2021 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the Apache 2.0 License along with this
+// software. If not, see <https://opensource.org/licenses/Apache-2.0>.
+
+#[macro_use]
+extern crate strict_encoding_derive;
+
+#[derive(NetworkEncode, NetworkDecode)]
+struct Tlv {
+    #[network_encoding(tlv = 0xCAFE)]
+    tlv: Option<u8>,
+}

--- a/tests/tlv-failures/wrong_unknown_type/mod.rs
+++ b/tests/tlv-failures/wrong_unknown_type/mod.rs
@@ -1,0 +1,15 @@
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(NetworkEncode, NetworkDecode)]
+#[network_encoding(use_tlv)]
+struct TlvUnknown {
+    field: Vec<u8>,
+
+    #[network_encoding(tlv = 1)]
+    tlv_int: Option<u16>,
+
+    #[network_encoding(tlv = 2)]
+    tlv_int2: Option<String>,
+
+    #[network_encoding(unknown_tlvs)]
+    rest_of_tlvs: BTreeMap<usize, Box<[u8]>>,
+}

--- a/tests/tlv.rs
+++ b/tests/tlv.rs
@@ -1,0 +1,280 @@
+#[macro_use]
+extern crate amplify;
+#[macro_use]
+extern crate strict_encoding_derive;
+#[macro_use]
+extern crate strict_encoding_test;
+
+mod common;
+use std::collections::BTreeMap;
+
+use common::{compile_test, Error, Result};
+use internet2::tlv;
+use strict_encoding::{strict_deserialize, StrictDecode};
+use strict_encoding_test::test_encoding_roundtrip;
+
+#[test]
+#[should_panic]
+fn tlv_no_strict() { compile_test("tlv-failures/no_strict"); }
+
+#[test]
+#[should_panic]
+fn tlv_no_enums() { compile_test("tlv-failures/no_enums"); }
+
+#[test]
+#[should_panic]
+fn tlv_no_unions() { compile_test("tlv-failures/no_unions"); }
+
+#[test]
+#[should_panic]
+fn tlv_non_u16_type() { compile_test("tlv-failures/tlv_non_u16_type"); }
+
+#[test]
+#[should_panic]
+fn tlv_undeclared() { compile_test("tlv-failures/tlv_undeclared"); }
+
+#[test]
+#[should_panic]
+fn wrong_unknown_type() { compile_test("tlv-failures/wrong_unknown_type"); }
+
+const TLV_U32: u32 = 0xDEADCAFE;
+macro_rules! tlv_u32 {
+    () => {
+        [
+            // Count of TLV elements:
+            0x01, 0x00, //
+            // Type field:
+            0xEF, 0xBE, //
+            // Length:
+            0x04, 0x00, //
+            // Value field:
+            0xFE, 0xCA, 0xAD, 0xDE,
+        ]
+    };
+}
+
+#[test]
+fn tlv_optional() -> Result {
+    #[derive(Clone, PartialEq, Eq, Debug, Default)]
+    #[derive(NetworkEncode, NetworkDecode)]
+    #[network_encoding(use_tlv)]
+    struct Tlv {
+        fixed: u8,
+
+        #[network_encoding(tlv = 0xBEEF)]
+        tlv: Option<u32>,
+    }
+
+    test_encoding_roundtrip(
+        &Tlv {
+            fixed: 0xDD,
+            tlv: None,
+        },
+        &[0xDD, 0x00, 0x00],
+    )?;
+    test_encoding_roundtrip(
+        &Tlv {
+            fixed: 0xDD,
+            tlv: Some(TLV_U32),
+        },
+        vec![0xDD]
+            .iter()
+            .chain(&tlv_u32!()[..])
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .map_err(Error::from)
+}
+
+#[test]
+fn tlv_newtype() -> Result {
+    #[derive(Clone, PartialEq, Eq, Debug, Default)]
+    #[derive(NetworkEncode, NetworkDecode)]
+    #[network_encoding(use_tlv)]
+    struct Tlv(#[network_encoding(tlv = 0xBEEF)] Option<u32>);
+
+    test_encoding_roundtrip(&Tlv(None), &[0x00, 0x00])?;
+    //    println!("{:02x?}", Tlv::strict_deserialize(tlv_u32!())?);
+    test_encoding_roundtrip(&Tlv(Some(TLV_U32)), tlv_u32!())
+        .map_err(Error::from)
+}
+
+#[test]
+fn tlv_default() -> Result {
+    #[derive(Clone, PartialEq, Eq, Debug, Default)]
+    #[derive(NetworkEncode, NetworkDecode)]
+    #[network_encoding(use_tlv)]
+    struct TlvDefault {
+        fixed: u8,
+
+        #[network_encoding(tlv = 0xBEEF)]
+        tlv: Vec<u8>,
+    }
+
+    test_encoding_roundtrip(&TlvDefault::default(), &[0x00; 3])?;
+
+    test_encoding_roundtrip(
+        &TlvDefault {
+            fixed: 0xDD,
+            tlv: TLV_U32.to_le_bytes().to_vec(),
+        },
+        vec![
+            0xdd, // =fixed
+            0x01, 0x00, // # of TLVs
+            0xef, 0xbe, // TLV type
+            0x06, 0x00, // TLV length
+            0x04, 0x00, 0xfe, 0xca, 0xad, 0xde, // Value: length + vec
+        ],
+    )
+    .map_err(Error::from)
+}
+
+#[test]
+fn tlv_ordering() -> Result {
+    #[derive(Clone, PartialEq, Eq, Debug, Default)]
+    #[derive(NetworkEncode, NetworkDecode)]
+    #[network_encoding(use_tlv)]
+    struct Tlv {
+        #[network_encoding(tlv = 0xCAFE)]
+        second: Option<u8>,
+
+        #[network_encoding(tlv = 0xBAD)]
+        first: Option<u8>,
+    }
+
+    let data = [
+        // Count of TLV fields
+        0x02, 0x00, //
+        // First goes first
+        0xAD, 0x0B, // type
+        0x01, 0x00, // length
+        0xA1, // value
+        // Second goes second
+        0xFE, 0xCA, // type
+        0x01, 0x00, // length
+        0xA2, // value
+    ];
+    let _: Tlv = strict_deserialize(&data).unwrap();
+
+    test_encoding_roundtrip(&Tlv::default(), &[0x00; 2])?;
+    test_encoding_roundtrip(
+        &Tlv {
+            second: Some(0xA2),
+            first: Some(0xA1),
+        },
+        &data,
+    )?;
+
+    // Now lets switch ordering
+    Tlv::strict_deserialize(&[
+        // Count of TLV fields
+        0x02, 0x00, //
+        // Second goes first
+        0xFE, 0xCA, // type
+        0x01, 0x00, // length
+        0xA1, // value
+        // First goes second
+        0xAD, 0x0B, // type
+        0x01, 0x00, // length
+        0xA1, // value
+    ])
+    .expect_err("");
+
+    Ok(())
+}
+
+#[test]
+fn pseudo_tlv() -> Result {
+    #[derive(Clone, PartialEq, Eq, Debug, Default)]
+    #[derive(NetworkEncode, NetworkDecode)]
+    #[network_encoding(use_tlv)]
+    struct Tlv {
+        vec: Vec<u8>,
+        unknown_tlvs: BTreeMap<usize, Box<[u8]>>,
+    }
+
+    let data1 = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let data2 = [
+        // vec:
+        0x03, 0x00, 0xB1, 0xB2, 0xB3, // empty map:
+        0x00, 0x00, // unknown_tlvs - auto added on top
+        0x00, 0x00,
+    ];
+
+    // Checking that the data are entirely consumed
+    let _: Tlv = strict_deserialize(&data1).unwrap();
+    let _: Tlv = strict_deserialize(&data2).unwrap();
+
+    test_encoding_roundtrip(&Tlv::default(), &data1)?;
+    test_encoding_roundtrip(
+        &Tlv {
+            vec: vec![0xB1, 0xB2, 0xB3],
+            unknown_tlvs: bmap! {},
+        },
+        &data2,
+    )
+    .map_err(Error::from)
+}
+
+#[test]
+fn tlv_collection() -> Result {
+    #[derive(Clone, PartialEq, Eq, Debug, Default)]
+    #[derive(NetworkEncode, NetworkDecode)]
+    #[network_encoding(use_tlv)]
+    struct Tlv {
+        #[network_encoding(tlv = 0xCAFE)]
+        map: BTreeMap<u8, String>,
+
+        #[network_encoding(tlv = 0xBAD)]
+        vec: Vec<u8>,
+    }
+
+    test_encoding_roundtrip(&Tlv::default(), &[0x00, 0x00])?;
+    test_encoding_roundtrip(
+        &Tlv {
+            map: bmap! { 0xA1u8 => s!("First"), 0xA2u8 => s!("Second") },
+            vec: vec![0xB1, 0xB2, 0xB3],
+        },
+        &[
+            // Count of TLV fields
+            0x02, 0x00, //
+            // First goes first
+            0xAD, 0x0B, // type
+            0x05, 0x00, // length
+            0x03, 0x00, 0xB1, 0xB2, 0xB3, // value
+            // Second goes second
+            0xFE, 0xCA, // type
+            0x13, 0x00, // length
+            0x02, 0x00, // value: # of map elements
+            0xA1, 0x05, 0x00, b'F', b'i', b'r', b's', b't', // first entry
+            0xA2, 0x06, 0x00, b'S', b'e', b'c', b'o', b'n', b'd',
+        ],
+    )
+    .map_err(Error::from)
+}
+
+#[test]
+fn tlv_stream() -> Result {
+    #[derive(Clone, PartialEq, Eq, Debug, Default)]
+    #[derive(NetworkEncode, NetworkDecode)]
+    #[network_encoding(use_tlv)]
+    struct TlvStream {
+        field: Vec<u8>,
+
+        #[network_encoding(tlv = 1)]
+        tlv_int: Option<u16>,
+
+        #[network_encoding(tlv = 2)]
+        tlv_int2: Option<String>,
+
+        #[network_encoding(unknown_tlvs)]
+        rest_of_tlvs: tlv::Stream,
+    }
+
+    test_encoding_roundtrip(&TlvStream::default(), &[0x00; 4])
+        .map_err(Error::from)
+}
+
+// TODO: Complete TLV encoding derivation test cases:
+//       - Failing on unknown even fields
+//       - Failed lengths etc


### PR DESCRIPTION
Lightning BOLT-1 specifies that TLV stream
- does not contain number of records
- encodes each type as BigSize
- encodes value length as BigSize

This PR implements this specification
